### PR TITLE
Fixed typographical error, changed Ceasar to Caesar in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ anything: can write anything
 The Fall of the Roman Empire
 ============================
 
-**Julius Ceasar** was...
+**Julius Caesar** was...
 
 ```
 
@@ -65,7 +65,7 @@ outputs...
 The Fall of the Roman Empire
 ============================
 
-**Julius Ceasar** was...
+**Julius Caesar** was...
 
 ```
 


### PR DESCRIPTION
jprichardson, I've corrected a typographical error in the documentation of the [node-markdown-extra](https://github.com/jprichardson/node-markdown-extra) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.